### PR TITLE
Novas páginas

### DIFF
--- a/encontros.md
+++ b/encontros.md
@@ -5,4 +5,8 @@ title: Eventos
 
 ## Meetup 2023 - Virtual
 
-Sendo este, o primeiro encontro, graças a iniciativa coletiva da comunidade Zig Brasil.
+Zig Meetup 2023, uma iniciativa coletiva da comunidade Zig Brasil, será um evento inteiramente virtual que acontecerá nos dias [data].
+
+Sendo este o primeiro encontro brasileiro dedicado a [Zig](https://ziglang.org/pt/), as palestras terão como objetivo disseminar conhecimento sobre essa nova linguagem de programação, apresentando ferramentas e características únicas que tornam Zig uma escolha atraente para desenvolver e manter software de forma robusta, otimizada, e reutilizável.
+
+A participação no evento é gratuita e será transmitido ao vivo pelas redes sociais, onde os participantes terão a oportunidade de fazer perguntas aos palestrantes, participar de discussões interativas e interagir com outros entusiastas através de chat e comentários.

--- a/encontros.md
+++ b/encontros.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Eventos
+---
+
+## Meetup 2023 - Virtual
+
+Sendo este, o primeiro encontro, graças a iniciativa coletiva da comunidade Zig Brasil.

--- a/palestrantes.md
+++ b/palestrantes.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Palestrantes
+---
+
+# Meetup 2023
+
+## Adelar Queiroz
+
+[IMG/FOTO]
+
+[Descrição]
+
+## Endel Dreyer
+
+[IMG/FOTO]
+
+[Descrição]
+
+## Felipe Stival
+
+[IMG/FOTO]
+
+[Descrição]
+
+## Rafael Batiati
+
+[IMG/FOTO]
+
+[Descrição]
+
+## Rafael Breno
+
+[IMG/FOTO]
+
+[Descrição]
+
+## Rodrigo Dornelles
+
+[IMG/FOTO]
+
+[Descrição]


### PR DESCRIPTION
* Eventos

Infelizmente, nesta página. Reconheço que ficou bastante vago para qualquer descrição real. Posso está enganado, mas talvez melhor seria descrever após o evento?

* Palestrantes

Está página ficou apenas como proposta de modelo, contendo os nomes do participantes, no qual, eles poderão se descrever e anexar o seu próprio perfil.

cc:

@endel
@rafaelbreno 
@v0idpwn 
@adelarsq 
@batiati 
@RodrigoDornelles 